### PR TITLE
[FR] Explicit BaseCampWorkerMaxNum note

### DIFF
--- a/fr/parameters.md
+++ b/fr/parameters.md
@@ -87,7 +87,7 @@ Dans ce document je vais vous expliquer les paramètres que vous pouvez modifier
 
 `BaseCampWorkerMaxNum=15` --> Nombre maximum de pals dans une base. 
 > [!NOTE]
-> Cette option n'est pas prise en compte sur les serveurs dédiés.
+> L'option `BaseCampWorkerMaxNum` n'est pas prise en compte sur les serveurs dédiés.
 
 `DropItemAliveMaxHours=1.000000` --> Définit le temps maximal pendant lequel les objets restent en vie après avoir été largués.
 


### PR DESCRIPTION
Rend la note qui indique que le paramètre n'est pas dispo sur serveur plus explicite sur le fait que cela ne concerne QUE le réglage BaseCampWorkerMaxNum.